### PR TITLE
Improve SEL function getAsText to use Locale.US than the default one

### DIFF
--- a/netflix-sel/src/main/java/com/netflix/sel/type/SelJodaDateTimeProperty.java
+++ b/netflix-sel/src/main/java/com/netflix/sel/type/SelJodaDateTimeProperty.java
@@ -14,6 +14,7 @@ package com.netflix.sel.type;
 
 import com.netflix.sel.visitor.SelOp;
 import java.util.Arrays;
+import java.util.Locale;
 import org.joda.time.DateTime;
 
 /** Wrapper class to support org.joda.time.DateTime.Property. */
@@ -52,7 +53,7 @@ public final class SelJodaDateTimeProperty extends AbstractSelType {
   public SelType call(String methodName, SelType[] args) {
     if (args.length == 0) {
       if ("getAsText".equals(methodName)) {
-        return SelString.of(val.getAsText());
+        return SelString.of(val.getAsText(Locale.US));
       } else if ("withMinimumValue".equals(methodName)) {
         return SelJodaDateTime.of(val.withMinimumValue());
       } else if ("withMaximumValue".equals(methodName)) {


### PR DESCRIPTION
Pull Request type
----
- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes (Please run `./gradlew build --write-locks` to refresh dependencies)
- [ ] Other (please describe):

**NOTE**: Please remember to run `./gradlew spotlessApply` to fix any format violations.

Changes in this PR

The current build will fail if the language is not EN because a unit test makes this assumption. By going over SEL code, it might not handle non-EN well. So update `getAsText` SEL function to always use `Locale.US`.
